### PR TITLE
Improved error handling

### DIFF
--- a/src/python_bayeux/__init__.py
+++ b/src/python_bayeux/__init__.py
@@ -461,6 +461,7 @@ class BayeuxClient(object):
             # If we have been called by a callback (that is, the client wants
             # to shut down itself), then we don't want to wait for the execute
             # greenlet to stop, because we'll deadlock.
+            # This also means that subclasses should not change self.greenlets
             relevant_greenlets = \
                 self.greenlets[:-1] \
                 if gevent.getcurrent() == self.greenlets[-1] \

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -152,6 +152,35 @@ def test_one_client(please_start_demo):
         assert client.value['data']['chat'] == code
 
 
+def test_one_client_go_then_block(please_start_demo):
+    # Using getpass() only because I know it handles the py.test tty redirect
+    # well
+    code = ''.join(random.choice(ascii_letters) for i in range(12))
+    getpass(
+        'Point a browser to \n'
+        'http://localhost:8080/jquery-examples/chat/\n'
+        'Enter a chat name, and click the Join button.\n'
+        'Watch for the chat prompt.  When prompted, '
+        'copy the following string into then chat'
+        ' : {0}\n'
+        'Hit enter when you are ready:'.format(
+            code
+        )
+    )
+    with ClientOne('http://localhost:8080/cometd') as client:
+        client.subscribe('/chat/demo', 'test_shutdown')
+        client.publish(
+            'Please enter the test code!',
+            'TestUser'
+        )
+        client.go()
+        try:
+            client.block()
+        except KeyboardInterrupt:
+            assert False
+        assert client.value['data']['chat'] == code
+
+
 def test_one_client_subscribe_timeouts(please_start_demo, monkeypatch):
     # Using getpass() only because I know it handles the py.test tty redirect
     # well


### PR DESCRIPTION
subscribe and unsubscribe now try again if requests time out

all greenlets that raise an unhandled exception now cause a clean client shutdown