### PR TITLE
Remove gevent.monkey.patch_all()

### DIFF
--- a/src/python_bayeux/__init__.py
+++ b/src/python_bayeux/__init__.py
@@ -28,9 +28,6 @@
     POSSIBILITY OF SUCH DAMAGE.
 '''
 
-import gevent.monkey
-gevent.monkey.patch_all()
-
 import simplejson as json
 import gevent
 import gevent.queue


### PR DESCRIPTION
This removes monkey.patch_all() since this should happen within the application using this library. 

See https://github.com/gevent/gevent/issues/1231#issuecomment-393945383 for reference.


The fact that python-bayeux is calling monkey.patch_all() is causing problems in an application we're developing. 